### PR TITLE
Update irq.c

### DIFF
--- a/drivers/of/irq.c
+++ b/drivers/of/irq.c
@@ -489,6 +489,7 @@ int of_irq_count(struct device_node *dev)
 
 	return nr;
 }
+EXPORT_SYMBOL_GPL(of_irq_count);
 
 /**
  * of_irq_to_resource_table - Fill in resource table with node's IRQ info


### PR DESCRIPTION
not able to use in linux device drivers since it's not declared in EXPORT_SYMBOL_GPL(of_irq_count) when compiling kernel modules separately